### PR TITLE
Initial proposal: dynamic schema and graphql server at runtime.

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -14,6 +14,7 @@ let Config = {
   GRAPHQL_SCHEMA_DIRECTIVES: {},
   EXPRESS_MIDDLEWARES: [],
   MOCKING: null,
+  LOADER: null,
 };
 
 export default Config;

--- a/server/core/main-server.js
+++ b/server/core/main-server.js
@@ -125,6 +125,8 @@ export const createApolloServer = (customOptions = {}, customConfig = {}) => {
       })
     );
   }
+  // this removes all handlers
+  WebApp.connectHandlers.stack = [];
   // this binds the specified paths to the Express server running Apollo + GraphiQL
   WebApp.connectHandlers.use(graphQLServer);
 

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -15,7 +15,11 @@ export default function initialize(config = {}) {
 
   Object.freeze(Config);
 
-  const schema = getExecutableSchema();
+  const schema = getExecutableSchema(
+    Config.LOADER && Config.LOADER.getSchema
+      ? Config.LOADER.getSchema.bind(Config.LOADER)
+      : undefined
+  );
 
   if (Config.MOCKING) {
     addMockFunctionsToSchema({

--- a/server/schema.js
+++ b/server/schema.js
@@ -1,12 +1,12 @@
 import { makeExecutableSchema } from 'graphql-tools';
-import { load, getSchema } from 'graphql-load';
+import { load, getSchema as defaultGetSchema } from 'graphql-load';
 import Config from './config';
 import directives from './directives';
 
 const EMPTY_QUERY_ERROR =
   'Error: Specified query type "Query" not found in document.';
 
-export function getExecutableSchema() {
+export function getExecutableSchema(getSchema = defaultGetSchema) {
   try {
     const { typeDefs, resolvers } = getSchema();
     schema = makeExecutableSchema({


### PR DESCRIPTION
@theodorDiaconu I'm the random dude that messaged you in the Meteor forum DM about dynamic schemas. As you know, I have a need to generate dynamic schemas at runtime. This is my initial attempt at making it possible to do runtime schema stitching with your libs. This pull request isn't the full solution but merely a humble proposal. I wanted to at least show some attempt and get feedback. There are three parts to this so far: 2 commits here and another PR in grapher-schema-directives repo.

1. I tested the idea on the grapher-performance repo and learned I could leverage your graphql-load package to merge new schemas & resolvers. (Awesome work on that btw!) So this PR allows for a Loader instance to be passed in via ```Config```. I figured I need to pass an instance instead of using the default/static one so I can have full control over what is loaded, and add and remove things at runtime.

2. The next thing I learned was calling initialize() a second time will rebuild the whole apollo server. I think this is okay, but grapher will attempt to call addLinks on existing collections with existing links. So there is another pull request on the c that merely checks if a link exists already before adding. I'll talk more about it on that pull request.

3. When initialize runs a second time it adds a new graphQLServer handler via ```WebApp.connectHandlers.use()```. I found that the "stack" in connect is not really a "stack". So the original ```graphQLServer``` is getting called and not the new one. To get around this I added a line that simply clears the stack via ```WebApp.connectHandlers.stack = []```. Clearly this is not the best idea, but I haven't found another way yet. 

Again, this is just a proof of concept. And I hope we can leverage this PR to build the right API for this use case. Perhaps there could be something like ```refreshServer({ loader })```.

Finally, all I've done as far as testing this is a few changes in the grapher-performance repo:
```
// server/load.js
const loader = new Loader()

loader.load([
  EntitiesModule,
  {
    typeDefs: [QueryType],
  },
])

loader.load({
  resolvers: QueryGrapherResolver,
})

initialize({ LOADER: loader })

Meteor.setTimeout(() => {
  loader.load({
    typeDefs: `type Query { sayHello: String }`,
    resolvers: {
      Query: { sayHello: () => 'Hello' },
    },
  })
  initialize()
}, 10 * 1000)
```

And boom, new merged schema and resolver visible in graphiql. My next step will be to generate the grapher resolvers automatically, and since they map so well:
```
// server/queries/QueryGrapher.resolver.js
// ...
    users(_, args, { db }, ast) {
      return db.users.astToQuery(ast).fetch();
    },

    comments(_, args, { db }, ast) {
      return db.comments.astToQuery(ast).fetch();
    },
// ...
```
It should be pretty painless. I wouldn't be surprised if you're already working on that!

Anyways, I hope you see the value in adding this as you've pretty much already done 95% of the work. Let me know what you think about adding a ```refreshServer({ loader })``` function and any other advice on the changes in these two PRs.

Thanks!