### PR TITLE
expose base context to context resolver, and allow for custom user resolving

### DIFF
--- a/.npm/package/.gitignore
+++ b/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npm/package/README
+++ b/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,10 @@
+{
+  "lockfileVersion": 1,
+  "dependencies": {
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    }
+  }
+}

--- a/package.js
+++ b/package.js
@@ -26,6 +26,10 @@ Package.onUse(function(api) {
   api.mainModule('server/index.js', 'server');
 });
 
+Npm.depends({
+  cookie: '0.4.0',
+});
+
 Package.onTest(function(api) {
   api.use('cultofcoders:apollo');
 

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -86,6 +86,7 @@ export default function initialize(apolloConfig = {}, meteorApolloConfig = {}) {
 function getContextCreator(meteorApolloConfig, initialApolloConfig) {
   const {
     context: defaultContextResolver,
+    meteorAccounts,
   } = initialApolloConfig;
 
   return async function getContext({ req: request, connection }) {
@@ -102,8 +103,7 @@ function getContextCreator(meteorApolloConfig, initialApolloConfig) {
       : {};
 
     let userContext = {};
-    if (Package['accounts-base']) {
-      const loginToken = req.headers['meteor-login-token'] || req.cookies['meteor-login-token'];
+    if (meteorAccounts !== false && Package['accounts-base']) {
       const loginToken =
         req.headers['meteor-login-token'] ||
         req.cookies['meteor-login-token'] ||

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -3,10 +3,10 @@ import { db } from 'meteor/cultofcoders:grapher';
 import { WebApp } from 'meteor/webapp';
 import { ApolloServer } from 'apollo-server-express';
 import { getSchema } from 'graphql-load';
+import cookie from 'cookie';
 import { AUTH_TOKEN_KEY } from '../constants';
 import defaultSchemaDirectives from './directives';
 import { getUserForContext } from './core/users';
-
 /**
  *
  * @param {*} apolloConfig Options https://www.apollographql.com/docs/apollo-server/api/apollo-server.html#constructor-options-lt-ApolloServer-gt
@@ -53,8 +53,8 @@ export default function initialize(apolloConfig = {}, meteorApolloConfig = {}) {
     typeDefs,
     resolvers,
     schemaDirectives,
-    context: getContextCreator(meteorApolloConfig, initialApolloConfig.context),
-    subscriptions: getSubscriptionConfig(meteorApolloConfig),
+    context: getContextCreator(meteorApolloConfig, initialApolloConfig),
+    subscriptions: getSubscriptionConfig(meteorApolloConfig, initialApolloConfig),
   };
 
   const server = new ApolloServer(apolloConfig);
@@ -83,51 +83,51 @@ export default function initialize(apolloConfig = {}, meteorApolloConfig = {}) {
   };
 }
 
-function getContextCreator(meteorApolloConfig, defaultContextResolver) {
-  return async function getContext({ req, connection }) {
+function getContextCreator(meteorApolloConfig, initialApolloConfig) {
+  const {
+    context: defaultContextResolver,
+  } = initialApolloConfig;
+
+  return async function getContext({ req: request, connection }) {
+    // This function is called whenever a normal graphql request is being made,
+    // as well as when a client initiates a new subscription. However, when a
+    // client subscribes, the request headers are not being send along. The
+    // websocket only send those on the onConnect event. We store them on the
+    // `connection.context` together with the parsed cookies, so we can
+    // reconstruct a fake request object to be used by the context creator.
+    const req = connection ? connection.context.req : request;
+
     const defaultContext = defaultContextResolver
       ? await defaultContextResolver({ req, connection })
       : {};
 
-    Object.assign(defaultContext, { db });
+    let userContext = {};
+    if (Package['accounts-base']) {
+      const loginToken = req.headers['meteor-login-token'] || req.cookies['meteor-login-token'];
+      const loginToken =
+        req.headers['meteor-login-token'] ||
+        req.cookies['meteor-login-token'] ||
+        req.connectionParams && req.connectionParams[AUTH_TOKEN_KEY];
 
-    if (connection) {
-      return {
-        ...defaultContext,
-        ...connection.context,
-      };
-    } else {
-      let userContext = {};
-      if (Package['accounts-base']) {
-        const loginToken =
-          req.headers['meteor-login-token'] || req.cookies['meteor-login-token'];
-        userContext = await getUserForContext(loginToken, meteorApolloConfig.userFields);
-      }
-
-      return {
-        ...defaultContext,
-        ...userContext,
-      };
+      userContext = await getUserForContext(loginToken, meteorApolloConfig.userFields);
     }
+
+    return {
+      db,
+      ...userContext,
+      ...defaultContext,
+    };
   };
 }
 
-function getSubscriptionConfig(meteorApolloConfig) {
+function getSubscriptionConfig() {
   return {
-    onConnect: async (connectionParams, webSocket, context) => {
-      const loginToken = connectionParams[AUTH_TOKEN_KEY];
+    onConnect: async (connectionParams, webSocket, { request }) => {
+      return new Promise(resolve => {
+        const headers = request.headers;
+        const cookies = cookie.parse(headers['cookie'] || '');
 
-      return new Promise((resolve, reject) => {
-        if (loginToken) {
-          const userContext = getUserForContext(
-            loginToken,
-            meteorApolloConfig.userFields
-          ).then(userContext => {
-            resolve(userContext);
-          });
-        } else {
-          resolve({});
-        }
+        return resolve({ req: { headers, cookies, connectionParams } });
       });
     },
   };


### PR DESCRIPTION
I changed the dataflow for the contexts a bit to fix two issues:

#49, I needed to be able to specify my own `user resolver`, and preferably disable the default one to prevent redundant DB hits.

#51, I needed the base context (db functionality) to be available in the context creator

The first one, can, for example, be used to replace the `users.find` query with a `users.findAndModify` to update his `lastActivity` timestamp. Or perhaps to use user accounts other than Meteor's native one.

This PR solves the issues above. I changed the way the context is being called, in such a way that it's being called for both the `http requests` as well as the `subscription requests`. The subscriptions now store their headers and cookies in the subscription context, which are then being passed down the context creator as fake request object.

This makes context management easier, as it now happens at a single place. This gives us full control of the context, regardless if we are in a subscription or http request.

```js
initialize({
  meteorAccounts: false, // disable apollo's default user lookup
  context: async ({ req, db }) => {
    const loginToken = req.cookies['api-key'];

    const user = await db.users.findOne({ loginToken });
    return { user };
  }
});
```

Another supported scenario is when we need the user object inside the context creator:

```js
initialize({
  context: async ({ req, user, userId }) => {
    const logger = initLogger({ user });
    return { logger };
  }
});
```

Or override the default `db` proxy

```js
initialize({
  context: async ({ req }) => {
    return { 
      db: {
        users: new Mongo.Collection('users').rawCollection(),
        // ...
      }
    };
  }
});
```

Again; all these contexts are merged with the base context, that is `{ db }` if `meteorAccounts === false`, and `{ db, user, userId }` otherwise. And all these contexts are available in both resolvers and queries, as well as subscriptions.

---

resolves #49 
resolves #51