### PR TITLE
feat: pass `res` to contextResolver

### DIFF
--- a/server/initialize.js
+++ b/server/initialize.js
@@ -90,7 +90,7 @@ function getContextCreator(meteorApolloConfig, initialApolloConfig) {
   } = initialApolloConfig;
 
   const baseContext = { db };
-  return async function getContext({ req: request, connection }) {
+  return async function getContext({ req: request, res, connection }) {
     // This function is called whenever a normal graphql request is being made,
     // as well as when a client initiates a new subscription. However, when a
     // client subscribes, the request headers are not being send along. The
@@ -112,6 +112,7 @@ function getContextCreator(meteorApolloConfig, initialApolloConfig) {
     const defaultContext = defaultContextResolver
       ? await defaultContextResolver({
           req,
+          res,
           connection,
           ...baseContext,
           ...userContext,


### PR DESCRIPTION
I've exposed the `response` object to the context creator. This enables me to log events once the request has been completed.

I use this to log response times:

```js
initialize({
  context: async ({ req, res }) => {
    const start = new Date().getTime();

    res.once('finish', () => {
      const duration = Date.now() - start;
      console.log(`graphql request took ${duration}ms`);
    });

    return { ... };
  }
});
```